### PR TITLE
Fix broken docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DB_HOST=localhost
 DB_USERNAME=root
 DB_DATABASE=testdb
 DB_PASSWORD=toor
+PORT=3306

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ npm start
 
 You can also use Docker to run the app. This will remove the requirement of MySQL installed on your local machine and will run MySQL in a Docker container.
 ```sh
-cp .env.example .env
 docker-compose up -d
 ```
 

--- a/db.js
+++ b/db.js
@@ -7,6 +7,7 @@ const db = new sequelize ({
     username: process.env.DB_USERNAME,
     database: process.env.DB_DATABASE,
     password: process.env.DB_PASSWORD,
+    port: process.env.PORT,
     dialect:"mysql"
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.2'
 services:
   app:
     build: .
@@ -7,16 +7,33 @@ services:
     volumes:
       - .:/app
       - /app/node_modules
+    environment:
+      - DB_HOST=mysql
+      - DB_USERNAME=root
+      - DB_DATABASE=testdb
+      - DB_PASSWORD=toor
+      - PORT=3306
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     ports:
       - 3100:3100
+    networks:
+      - mint
   mysql:
     image: mysql:5.6
+    healthcheck:
+      test: ["CMD", "mysql" ,"-h", "mysql", "-P", "3306", "-u", "root", "--password=toor", "-e", "SELECT 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
     environment:
         MYSQL_ROOT_PASSWORD: toor
         MYSQL_DATABASE: testdb
-        MYSQL_USER: root
-        MYSQL_PASSWORD: toor
-    ports:
-        - 33061:3306
+    expose:
+      - 3306
+    networks:
+      - mint
+
+networks:
+  mint:


### PR DESCRIPTION
Updated readme to remove copy of .env.example. The configuration options
provided were incorrect for the docker compose services

Added configuration via env vars in docker-compose file

Rolled docker-compose version back to v2.2 due to depends_on
v3 depends_on will allow dependent services to start once the mysql
service container has started. However because the mysql container is
running does not mean it is able to accept connections.

v2 of docker-compose suppots health checks which will prevent dependent
services starting until the mysql services is ready to accept connections

Added a docker-compose network to isolate mysql service and prevent port collisions (3306)
on local environments